### PR TITLE
skip window maximize test by default

### DIFF
--- a/test/src/window_test.dart
+++ b/test/src/window_test.dart
@@ -30,7 +30,7 @@ void main() {
     });
 
     // May not work on some OS/browser combinations (notably Mac OS X).
-    test('maximize', () async {
+    skip_test('maximize', () async {
       var window = await driver.window;
       await window.setSize(const Size(200, 300));
       await window.setLocation(const Point(100, 200));


### PR DESCRIPTION
I am getting very strange behavior with this test as I try to make it more reliable (I actually think there is a bug in chromedriver), so I propose that we just skip it by default.
